### PR TITLE
Fix Docker image tag and container volume path in build environment setup

### DIFF
--- a/edk2-build-toolchain/README.md
+++ b/edk2-build-toolchain/README.md
@@ -11,7 +11,7 @@ There are two ways to obtain the docker image:
 To build the container image, run the following command at the root of the project:
 
 ``` console
-docker build --tag dvuefi-build edk2-build-toolchain
+docker build --tag debian-qemu-uefi edk2-build-toolchain
 ```
 
 This will build a new image named `debian-qemu-uefi` (feel free to use any other name you'd like).
@@ -29,7 +29,7 @@ We can run the container and give it access to the `vuln-edk2` directory so that
 We do that using `--volume`
 
 ```console
-docker run --volume ./vuln-edk2:/home/edk2 --rm -it debian-qemu-uefi
+docker run --volume ./vuln-edk2:/home/vuln-edk2 --rm -it debian-qemu-uefi
 
 user@docker:/home#
 ```


### PR DESCRIPTION
This PR fixes minor typos in the documentation for setting up the build environment in Docker.

- The Docker build command now uses the correct image tag `debian-qemu-uefi` to ensure consistency.
- Updated the `--volume` argument in the Docker command to correctly map the local `./vuln-edk2` directory to the appropriate directory inside the container - consistent with the rest of the document.

These minor changes prevent potential confusion with setup of build environment.
